### PR TITLE
Potential fix for code scanning alert no. 5: Reflected server-side cross-site scripting

### DIFF
--- a/ebs/verifiedfirst/main/routes.py
+++ b/ebs/verifiedfirst/main/routes.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 
 from flask import Blueprint, Response, abort, jsonify, make_response, request, current_app
+from markupsafe import escape
 from requests import RequestException
 
 from verifiedfirst import twitch, verify
@@ -119,7 +120,7 @@ def eventsub() -> Response:
     if message_type == "webhook_callback_verification":
         challenge = request_data["challenge"]
         current_app.logger.info("responding to challenge: %s", challenge)
-        return make_response(challenge)
+        return make_response(escape(challenge), 200, {"Content-Type": "text/plain"})
 
     if message_type == "notification":
         broadcaster_id = int(request_data["event"]["broadcaster_user_id"])


### PR DESCRIPTION
Potential fix for [https://github.com/jaedolph/verified-first/security/code-scanning/5](https://github.com/jaedolph/verified-first/security/code-scanning/5)

To prevent reflected server-side XSS in this context, ensure that the response containing the user-controlled challenge value is not interpreted as HTML by user agents. The best approach is to set the response Content-Type to `text/plain` to ensure browsers do not treat it as executable HTML, as required by the Twitch EventSub webhook verification spec (which expects a plain text response body). Additionally, you may use Flask's `escape()` function if you wish to further prevent injection, but the main requirement is correct Content-Type.

The recommended fix is to explicitly set the Content-Type to `'text/plain'` in the response on line 122, in the handler for the `webhook_callback_verification` message. This can be done by passing the `content_type` or `mimetype` parameter to `make_response`. No need for escaping in this protocol, since Twitch expects the exact challenge string to be echoed back as text, not HTML.

You only have to edit lines around the return statement for the challenge in the `/eventsub` endpoint, and possibly add a relevant import if needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
