### PR TITLE
Fix NameError on connection errors in Twitch API request functions

### DIFF
--- a/ebs/tests/test_twitch.py
+++ b/ebs/tests/test_twitch.py
@@ -184,7 +184,9 @@ def test_request_twitch_api_broadcaster_refresh(
     mock_error_response.status_code = 401
     mock_good_response = mocker.Mock()
 
-    mock_error_response.raise_for_status.side_effect = RequestException("test exception")
+    test_exception = RequestException("test exception")
+    test_exception.response = mock_error_response
+    mock_error_response.raise_for_status.side_effect = test_exception
 
     mock_request_twitch_api = mocker.patch("verifiedfirst.twitch.request_twitch_api")
     mock_request_twitch_api.side_effect = [
@@ -233,7 +235,9 @@ def test_request_twitch_api_broadcaster_refresh_fail(
     mock_error_response = mocker.Mock()
     mock_error_response.status_code = 401
 
-    mock_error_response.raise_for_status.side_effect = RequestException("test exception")
+    test_exception = RequestException("test exception")
+    test_exception.response = mock_error_response
+    mock_error_response.raise_for_status.side_effect = test_exception
 
     mock_request_twitch_api = mocker.patch("verifiedfirst.twitch.request_twitch_api")
     mock_request_twitch_api.return_value = mock_error_response
@@ -308,7 +312,9 @@ def test_request_twitch_api_app_refresh(app, mocker, caplog):
     mock_error_response = mocker.Mock()
     mock_error_response.status_code = 401
     mock_good_response = mocker.Mock()
-    mock_error_response.raise_for_status.side_effect = RequestException("test exception")
+    test_exception = RequestException("test exception")
+    test_exception.response = mock_error_response
+    mock_error_response.raise_for_status.side_effect = test_exception
 
     mock_request_twitch_api = mocker.patch("verifiedfirst.twitch.request_twitch_api")
     mock_request_twitch_api.side_effect = [
@@ -345,7 +351,9 @@ def test_request_twitch_api_app_refresh_fail(app, mocker, caplog):
     mock_error_response = mocker.Mock()
     mock_error_response.status_code = 401
     mock_good_response = mocker.Mock()
-    mock_error_response.raise_for_status.side_effect = RequestException("test exception")
+    test_exception = RequestException("test exception")
+    test_exception.response = mock_error_response
+    mock_error_response.raise_for_status.side_effect = test_exception
 
     mock_request_twitch_api = mocker.patch("verifiedfirst.twitch.request_twitch_api")
     mock_request_twitch_api.side_effect = [

--- a/ebs/verifiedfirst/twitch.py
+++ b/ebs/verifiedfirst/twitch.py
@@ -154,7 +154,7 @@ def request_twitch_api_broadcaster(broadcaster: Broadcaster, request: Request) -
         return resp
     except RequestException as exp:
         current_app.logger.error("request to twitch api failed: %s", exp)
-        if resp.status_code != codes.unauthorized:
+        if exp.response is None or exp.response.status_code != codes.unauthorized:
             raise exp
 
     # if we get an unauthorized response, try to refresh the token
@@ -187,7 +187,7 @@ def request_twitch_api_app(request: Request) -> Response:
         return resp
     except RequestException as exp:
         current_app.logger.error("request to twitch api failed: %s", exp)
-        if resp.status_code != codes.unauthorized:
+        if exp.response is None or exp.response.status_code != codes.unauthorized:
             raise exp
 
     # if we get an unauthorized response, try to refresh the token


### PR DESCRIPTION
## Summary

- `request_twitch_api_broadcaster` and `request_twitch_api_app` both accessed `resp` inside an `except RequestException` block, but `resp` is only assigned if `request_twitch_api()` returns successfully
- Any connection-level failure (timeout, DNS, refused connection) raises before a response is received, so `resp` is never defined — the except block then crashes with `NameError: name 'resp' is not defined`
- Fixed by using `exp.response` instead (set by the `requests` library on the exception): `None` for connection errors, the HTTP response object for HTTP errors — which correctly re-raises on connection failures and non-401 HTTP errors, and falls through to token refresh only on 401

## Test plan

- [x] Simulate a connection timeout to the Twitch API — should propagate the exception cleanly, not crash with `NameError`
- [x] Simulate a non-401 HTTP error (e.g. 500) — should re-raise the exception
- [x] Simulate a 401 response — should fall through to the token refresh logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)