### PR TITLE
Return 400 when reward_id query param is missing from /eventsub/create

### DIFF
--- a/ebs/tests/test_main.py
+++ b/ebs/tests/test_main.py
@@ -128,6 +128,17 @@ def test_eventsub_create_not_broadcaster(client, mocker):
     assert resp.json["error"] == "user role is not broadcaster"
 
 
+def test_eventsub_create_missing_reward_id(client, mocker):
+    """Test that a missing reward_id query param returns 400."""
+    mock_jwt = mocker.patch("verifiedfirst.verify.verify_jwt")
+    mock_jwt.return_value = (defaults.CHANNEL_ID, "broadcaster")
+
+    resp = client.post(url_for("main.eventsub_create"))
+
+    assert resp.status_code == 400
+    assert resp.json["error"] == "reward_id is required"
+
+
 def test_eventsub_create_undefined(client, mocker):
     """Test that an 'undefined' reward id is rejected."""
     mock_jwt = mocker.patch("verifiedfirst.verify.verify_jwt")

--- a/ebs/verifiedfirst/main/routes.py
+++ b/ebs/verifiedfirst/main/routes.py
@@ -58,7 +58,10 @@ def eventsub_create(channel_id: int, role: str) -> Response:
     if role != "broadcaster":
         abort(403, "user role is not broadcaster")
 
-    reward_id = request.args["reward_id"]
+    reward_id = request.args.get("reward_id")
+
+    if reward_id is None:
+        abort(400, "reward_id is required")
 
     if reward_id == "undefined":
         abort(400, "reward id is undefined")


### PR DESCRIPTION
## Summary

- `request.args["reward_id"]` raises `KeyError` when the `reward_id` query parameter is absent, which Flask converts to a 500 Internal Server Error
- Changed to `request.args.get("reward_id")` with an explicit `abort(400, "reward_id is required")` so the client gets a meaningful 400 response

## Test plan

- [x] `POST /eventsub/create` with no `reward_id` param — should return 400, not 500
- [x] `POST /eventsub/create` with `reward_id=undefined` — should still return 400 (existing check)
- [x] `POST /eventsub/create` with a valid `reward_id` — normal flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)