### PR TITLE
Remove duplicate unauthenticated HTTP request in parse_firsts check_user

### DIFF
--- a/ebs/scripts/parse_firsts.py
+++ b/ebs/scripts/parse_firsts.py
@@ -2,7 +2,6 @@
 import csv
 from datetime import datetime
 
-import requests
 from flask import current_app
 from requests import Request
 
@@ -24,16 +23,6 @@ def check_user(broadcaster, display_name):
         },
     )
 
-    resp = requests.get(
-        "https://api.twitch.tv/helix/users",
-        params={
-            "login": username,
-        },
-        timeout=5,
-        headers={
-            "Client-Id": current_app.config["CLIENT_ID"],
-        },
-    )
     resp = twitch.request_twitch_api_broadcaster(broadcaster, req)
     resp.raise_for_status()
     try:


### PR DESCRIPTION
## Summary

- `check_user` in `scripts/parse_firsts.py` was making two HTTP requests per user lookup: first a raw `requests.get()` call (hardcoded URL, no auth token), then immediately overwriting `resp` with a proper authenticated call via `request_twitch_api_broadcaster()`
- The first request's response was always discarded — the call had no effect except wasting a network round-trip on every row in the CSV
- Removed the dead `requests.get()` block and the now-unused `import requests`

## Test plan

- [x] Run `parse_firsts.py` against a test CSV — should produce the same results with fewer network calls
- [x] Confirm user lookups still succeed via the authenticated Twitch API call

🤖 Generated with [Claude Code](https://claude.com/claude-code)