### PR TITLE
Replace assert with ValueError in get_firsts user lookup

### DIFF
--- a/ebs/tests/test_twitch.py
+++ b/ebs/tests/test_twitch.py
@@ -931,9 +931,7 @@ def test_get_firsts_missing_user(app, init_db):
     broadcaster = type("B", (), {"id": defaults.BROADCASTER_ID})()
 
     # Add a First with a user_id that has no matching User row (data inconsistency)
-    database.session.add(
-        First(broadcaster_id=defaults.BROADCASTER_ID, name="ghost", user_id=9999)
-    )
+    database.session.add(First(broadcaster_id=defaults.BROADCASTER_ID, name="ghost", user_id=9999))
     database.session.commit()
 
     with pytest.raises(ValueError):

--- a/ebs/tests/test_twitch.py
+++ b/ebs/tests/test_twitch.py
@@ -924,6 +924,22 @@ def test_get_firsts_mixed_legacy_and_new(app, init_db):
     assert firsts["legacyuser"] == 1
 
 
+def test_get_firsts_missing_user(app, init_db):
+    """Test get_firsts raises ValueError when a First row references a deleted user."""
+    database = init_db(app)
+
+    broadcaster = type("B", (), {"id": defaults.BROADCASTER_ID})()
+
+    # Add a First with a user_id that has no matching User row (data inconsistency)
+    database.session.add(
+        First(broadcaster_id=defaults.BROADCASTER_ID, name="ghost", user_id=9999)
+    )
+    database.session.commit()
+
+    with pytest.raises(ValueError):
+        twitch.get_firsts(broadcaster)
+
+
 def test_update_reward(app, init_db):
     """Test update_reward function."""
     database = init_db(app)

--- a/ebs/verifiedfirst/twitch.py
+++ b/ebs/verifiedfirst/twitch.py
@@ -322,7 +322,8 @@ def get_firsts(
     first_counts: dict[str, Any] = {}
     for user_id, count in counts_by_user_id.items():
         user = db.session.get(User, user_id)
-        assert user is not None
+        if user is None:
+            raise ValueError(f"User {user_id} referenced in firsts but not found in database")
         first_counts[user.name] = count
     for name, count in counts_by_name.items():
         first_counts[name] = first_counts.get(name, 0) + count


### PR DESCRIPTION
## Summary

- `get_firsts` used `assert user is not None` to guard against a `First` row referencing a `User` that no longer exists in the database
- `assert` can be silently disabled at the interpreter level with Python's `-O` flag, meaning this guard disappears entirely in optimized deployments — the code then crashes with `AttributeError` on the next line instead of the intended guard
- Replaced with an explicit `if user is None: raise ValueError(...)` which is always enforced and produces a clear, descriptive error message

## Test plan

- [ ] Normal path: `get_firsts` returns correct counts when all referenced users exist
- [ ] Data inconsistency path: if a `First` row references a missing `user_id`, should now raise `ValueError` with a descriptive message rather than `AssertionError` or `AttributeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)