### PR TITLE
Fix pre-existing docstring formatting violations (docformatter)

### DIFF
--- a/ebs/tests/conftest.py
+++ b/ebs/tests/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures and helper functions for testing."""
+
 from contextlib import contextmanager
 from datetime import datetime, UTC
 import os

--- a/ebs/tests/test_auth.py
+++ b/ebs/tests/test_auth.py
@@ -8,7 +8,6 @@ from . import defaults
 
 def test_auth(app, client, mocker):  # pylint: disable=unused-argument
     """Test /auth endpoint works correctly."""
-
     good_response = render_template("auth.html", auth_msg="AUTH_SUCCESSFUL")
     mock_get_auth_tokens = mocker.patch("verifiedfirst.twitch.get_auth_tokens")
     mock_get_auth_tokens.return_value = (defaults.AUTH_ACCESS_TOKEN, defaults.AUTH_REFRESH_TOKEN)
@@ -34,7 +33,6 @@ def test_auth(app, client, mocker):  # pylint: disable=unused-argument
 
 def test_auth_rejected(app, client):  # pylint: disable=unused-argument
     """Test /auth returns an error if the user rejected the prompt."""
-
     bad_response = render_template("auth.html", auth_msg="AUTH_FAILED")
 
     resp = client.get(
@@ -51,7 +49,6 @@ def test_auth_rejected(app, client):  # pylint: disable=unused-argument
 
 def test_auth_error(app, client, mocker):  # pylint: disable=unused-argument
     """Test /auth returns an error if request to the oauth api fails."""
-
     bad_response = render_template("auth.html", auth_msg="AUTH_FAILED")
     mock_get_auth_tokens = mocker.patch("verifiedfirst.twitch.get_auth_tokens")
     mock_get_auth_tokens.side_effect = HTTPError
@@ -71,7 +68,6 @@ def test_auth_error(app, client, mocker):  # pylint: disable=unused-argument
 
 def test_auth_check(app, client, mocker):  # pylint: disable=unused-argument
     """Test /auth/check endpoint works correctly."""
-
     mock_jwt = mocker.patch("verifiedfirst.verify.verify_jwt")
     mock_jwt.return_value = (defaults.CHANNEL_ID, "broadcaster")
 
@@ -92,7 +88,6 @@ def test_auth_check(app, client, mocker):  # pylint: disable=unused-argument
 
 def test_auth_check_not_broadcaster(app, client, mocker):  # pylint: disable=unused-argument
     """Test /auth/check fails if the user accessing it is not a broadcaster."""
-
     mock_jwt = mocker.patch("verifiedfirst.verify.verify_jwt")
     mock_jwt.return_value = (defaults.CHANNEL_ID, "viewer")
     mock_get_broadcaster = mocker.patch("verifiedfirst.twitch.get_broadcaster")
@@ -109,7 +104,6 @@ def test_auth_check_not_broadcaster(app, client, mocker):  # pylint: disable=unu
 
 def test_auth_check_broadcaster_not_found(app, client, mocker):  # pylint: disable=unused-argument
     """Test /auth/check fails if the broadcaster is not in the database."""
-
     mock_jwt = mocker.patch("verifiedfirst.verify.verify_jwt")
     mock_jwt.return_value = (defaults.CHANNEL_ID, "broadcaster")
     mock_get_broadcaster = mocker.patch("verifiedfirst.twitch.get_broadcaster")
@@ -128,7 +122,6 @@ def test_auth_check_broadcaster_not_found(app, client, mocker):  # pylint: disab
 
 def test_auth_check_auth_invalid(app, client, mocker):  # pylint: disable=unused-argument
     """Test /auth/check fails if the auth token in the database is invalid/stale."""
-
     mock_jwt = mocker.patch("verifiedfirst.verify.verify_jwt")
     mock_jwt.return_value = (defaults.CHANNEL_ID, "broadcaster")
 

--- a/ebs/tests/test_errors.py
+++ b/ebs/tests/test_errors.py
@@ -12,7 +12,6 @@ RESPONSE_DICT = {"error": ERROR_MSG}
 @pytest.fixture(name="mock_exception")
 def fixture_mock_exception(mocker):
     """Mocks exception to pass to error handlers."""
-
     mock_exception = mocker.Mock()
     mock_exception.description = ERROR_MSG
 
@@ -21,7 +20,6 @@ def fixture_mock_exception(mocker):
 
 def test_bad_request(app, mock_exception):  # pylint: disable=unused-argument
     """Test bad_request handler."""
-
     response = handlers.bad_request(mock_exception)
 
     assert isinstance(response, Response)
@@ -31,7 +29,6 @@ def test_bad_request(app, mock_exception):  # pylint: disable=unused-argument
 
 def test_unauthorized(app, mock_exception):  # pylint: disable=unused-argument
     """Test unauthorized handler."""
-
     response = handlers.unauthorized(mock_exception)
 
     assert isinstance(response, Response)
@@ -41,7 +38,6 @@ def test_unauthorized(app, mock_exception):  # pylint: disable=unused-argument
 
 def test_forbidden(app, mock_exception):  # pylint: disable=unused-argument
     """Test forbidden handler."""
-
     response = handlers.forbidden(mock_exception)
 
     assert isinstance(response, Response)
@@ -51,7 +47,6 @@ def test_forbidden(app, mock_exception):  # pylint: disable=unused-argument
 
 def test_not_found(app, mock_exception):  # pylint: disable=unused-argument
     """Test not_found handler."""
-
     response = handlers.not_found(mock_exception)
 
     assert isinstance(response, Response)
@@ -61,7 +56,6 @@ def test_not_found(app, mock_exception):  # pylint: disable=unused-argument
 
 def test_internal_server_error(app, mock_exception):  # pylint: disable=unused-argument
     """Test internal_server_error handler."""
-
     response = handlers.internal_server_error(mock_exception)
 
     assert isinstance(response, Response)

--- a/ebs/tests/test_main.py
+++ b/ebs/tests/test_main.py
@@ -1,4 +1,5 @@
 """Tests for main routes."""
+
 from datetime import datetime
 
 from flask import url_for
@@ -9,7 +10,6 @@ from . import defaults
 
 def test_firsts(client, mocker):
     """Test the /firsts endpoint works."""
-
     firsts = {
         "user1": 5,
         "user2": 3,
@@ -60,7 +60,6 @@ def test_firsts(client, mocker):
 
 def test_firsts_no_broadcaster(client, mocker):
     """Test the /firsts returns a 403 if the broadcaster is not authed."""
-
     mock_jwt = mocker.patch("verifiedfirst.verify.verify_jwt")
     mock_jwt.return_value = (defaults.CHANNEL_ID, "viewer")
     mock_get_broadcaster = mocker.patch("verifiedfirst.twitch.get_broadcaster")
@@ -77,7 +76,6 @@ def test_firsts_no_broadcaster(client, mocker):
 
 def test_firsts_no_firsts(client, mocker):
     """Test the /firsts returns a 404 if no firsts are returned."""
-
     mock_jwt = mocker.patch("verifiedfirst.verify.verify_jwt")
     mock_jwt.return_value = (defaults.CHANNEL_ID, "viewer")
     mock_get_broadcaster = mocker.patch("verifiedfirst.twitch.get_broadcaster")
@@ -96,7 +94,6 @@ def test_firsts_no_firsts(client, mocker):
 
 def test_eventsub_create(client, mocker):
     """Test the /eventsub/create endpoint works."""
-
     mock_jwt = mocker.patch("verifiedfirst.verify.verify_jwt")
     mock_jwt.return_value = (defaults.CHANNEL_ID, "broadcaster")
     mock_broadcaster = mocker.Mock()
@@ -120,7 +117,6 @@ def test_eventsub_create(client, mocker):
 
 def test_eventsub_create_not_broadcaster(client, mocker):
     """Test that only broadcasters can use the /eventsub/create endpoint."""
-
     mock_jwt = mocker.patch("verifiedfirst.verify.verify_jwt")
 
     mock_jwt.return_value = (defaults.CHANNEL_ID, "viewer")
@@ -134,7 +130,6 @@ def test_eventsub_create_not_broadcaster(client, mocker):
 
 def test_eventsub_create_undefined(client, mocker):
     """Test that an 'undefined' reward id is rejected."""
-
     mock_jwt = mocker.patch("verifiedfirst.verify.verify_jwt")
     reward_id = "undefined"
 
@@ -147,7 +142,6 @@ def test_eventsub_create_undefined(client, mocker):
 
 def test_eventsub_create_unauthed(client, mocker):
     """Test that a 403 is returned if the broadcaster has not authed yet."""
-
     mock_jwt = mocker.patch("verifiedfirst.verify.verify_jwt")
     mock_jwt.return_value = (defaults.CHANNEL_ID, "broadcaster")
     mock_get_broadcaster = mocker.patch("verifiedfirst.twitch.get_broadcaster")
@@ -164,7 +158,6 @@ def test_eventsub_create_unauthed(client, mocker):
 
 def test_rewards(client, mocker):
     """Test the /rewards endpoint works."""
-
     mock_jwt = mocker.patch("verifiedfirst.verify.verify_jwt")
     mock_jwt.return_value = (defaults.CHANNEL_ID, "broadcaster")
     mock_broadcaster = mocker.Mock()
@@ -182,7 +175,6 @@ def test_rewards(client, mocker):
 
 def test_rewards_not_broadcaster(client, mocker):
     """Test that only broadcasters can get rewards."""
-
     mock_jwt = mocker.patch("verifiedfirst.verify.verify_jwt")
     mock_jwt.return_value = (defaults.CHANNEL_ID, "viewer")
 
@@ -194,7 +186,6 @@ def test_rewards_not_broadcaster(client, mocker):
 
 def test_rewards_unauthed(client, mocker):
     """Test that a 403 is returned if the broadcaster has not authed yet."""
-
     mock_jwt = mocker.patch("verifiedfirst.verify.verify_jwt")
     mock_jwt.return_value = (defaults.CHANNEL_ID, "broadcaster")
     mock_get_broadcaster = mocker.patch("verifiedfirst.twitch.get_broadcaster")
@@ -208,7 +199,6 @@ def test_rewards_unauthed(client, mocker):
 
 def test_rewards_no_rewards(client, mocker):
     """Test that 500 error if getting rewards fails."""
-
     mock_jwt = mocker.patch("verifiedfirst.verify.verify_jwt")
     mock_jwt.return_value = (defaults.CHANNEL_ID, "broadcaster")
     mock_broadcaster = mocker.Mock()
@@ -225,7 +215,6 @@ def test_rewards_no_rewards(client, mocker):
 
 def test_eventsub_challenge(client, mocker):
     """Test the /eventsub endpoint responds to a challenge request."""
-
     mock_verify_eventsub_message = mocker.patch("verifiedfirst.verify.verify_eventsub_message")
     mock_verify_eventsub_message.return_value = True
     mock_add_first = mocker.patch("verifiedfirst.twitch.add_first")
@@ -245,7 +234,6 @@ def test_eventsub_challenge(client, mocker):
 
 def test_eventsub_notification(client, mocker):
     """Test an eventsub notification adds a "first" for the correct broadcaster."""
-
     mock_verify_eventsub_message = mocker.patch("verifiedfirst.verify.verify_eventsub_message")
     mock_verify_eventsub_message.return_value = True
     mock_add_first = mocker.patch("verifiedfirst.twitch.add_first")
@@ -275,7 +263,6 @@ def test_eventsub_notification(client, mocker):
 
 def test_eventsub_revocation(client, mocker):
     """Test an eventsub revocation deletes the eventsub for that broadcaster."""
-
     mock_verify_eventsub_message = mocker.patch("verifiedfirst.verify.verify_eventsub_message")
     mock_verify_eventsub_message.return_value = True
     mock_add_first = mocker.patch("verifiedfirst.twitch.add_first")
@@ -298,7 +285,6 @@ def test_eventsub_revocation(client, mocker):
 
 def test_eventsub_bad_message_type(client, mocker):
     """Test that an unhandled message type throws an error."""
-
     mock_verify_eventsub_message = mocker.patch("verifiedfirst.verify.verify_eventsub_message")
     mock_verify_eventsub_message.return_value = True
 
@@ -317,7 +303,6 @@ def test_eventsub_bad_message_type(client, mocker):
 
 def test_eventsub_bad_hmac(client, mocker):
     """Test the /eventsub endpoint fails if hmac doesn't verify."""
-
     mock_verify_eventsub_message = mocker.patch("verifiedfirst.verify.verify_eventsub_message")
     mock_verify_eventsub_message.return_value = False
 

--- a/ebs/tests/test_scripts.py
+++ b/ebs/tests/test_scripts.py
@@ -24,7 +24,6 @@ USERS = {
 
 def test_init_db(integrationtestconfig):
     """Test that the database can be loaded using the init_db.py script."""
-
     # run the init_db console script
     initdb = subprocess.run(
         [sys.executable, "verifiedfirst/init_db.py"],
@@ -61,7 +60,6 @@ def test_init_db(integrationtestconfig):
 
 def test_main(integrationtestconfig, generate_jwt):  # pylint: disable=unused-argument
     """Test that the verifiedfirst web server can be run using the __main__.py script."""
-
     # # run the verifiedfirst web server
     with subprocess.Popen(
         [sys.executable, "verifiedfirst/__main__.py"], stdin=subprocess.PIPE, stderr=subprocess.PIPE

--- a/ebs/tests/test_twitch.py
+++ b/ebs/tests/test_twitch.py
@@ -1,4 +1,5 @@
 """Tests for functions that interact with the Twitch API."""
+
 from datetime import datetime
 from urllib.parse import quote
 
@@ -153,7 +154,6 @@ def test_request_twitch_api_broadcaster(app, caplog, mocker):  # pylint: disable
 def test_request_twitch_api_broadcaster_404(app, caplog, mocker):  # pylint: disable=unused-argument
     """Test request_twitch_api_broadcaster throws the correct exception if the twitch API returns an
     error (other than unauthorized)"""
-
     mock_request = mocker.Mock()
     mock_response = mocker.Mock()
     mock_response.status_code = 404
@@ -179,7 +179,6 @@ def test_request_twitch_api_broadcaster_refresh(
 ):  # pylint: disable=too-many-locals,unused-argument
     """Test request_twitch_api_broadcaster refreshes the access token if the first request gets a
     401 error."""
-
     mock_request = mocker.Mock()
     mock_error_response = mocker.Mock()
     mock_error_response.status_code = 401
@@ -230,7 +229,6 @@ def test_request_twitch_api_broadcaster_refresh_fail(
 ):  # pylint: disable=unused-argument
     """Test request_twitch_api_broadcaster throws the correct exception if the token refresh
     fails."""
-
     mock_request = mocker.Mock()
     mock_error_response = mocker.Mock()
     mock_error_response.status_code = 401
@@ -285,7 +283,6 @@ def test_request_twitch_api_app(app, mocker, caplog):
 def test_request_twitch_api_app_404(app, mocker, caplog):
     """Test request_twitch_api_app function throws an exception if the twitch API returns an error
     (other than unauthorized)"""
-
     mock_request = mocker.Mock()
     mock_response = mocker.Mock()
     mock_response.status_code = 404
@@ -307,7 +304,6 @@ def test_request_twitch_api_app_404(app, mocker, caplog):
 def test_request_twitch_api_app_refresh(app, mocker, caplog):
     """Test request_twitch_api_app function refreshes the token if the first request gets a 401
     error."""
-
     mock_request = mocker.Mock()
     mock_error_response = mocker.Mock()
     mock_error_response.status_code = 401
@@ -345,7 +341,6 @@ def test_request_twitch_api_app_refresh(app, mocker, caplog):
 
 def test_request_twitch_api_app_refresh_fail(app, mocker, caplog):
     """Test request_twitch_api_app function throws the correct error if the token refresh fails."""
-
     mock_request = mocker.Mock()
     mock_error_response = mocker.Mock()
     mock_error_response.status_code = 401
@@ -499,7 +494,6 @@ def test_get_rewards(app, mocker):
 
 def test_get_rewards_403(app, mocker):  # pylint: disable=unused-argument
     """Test get_rewards throws the correct exception if the twitch API returns an error."""
-
     mock_request_twitch_api = mocker.patch("verifiedfirst.twitch.request_twitch_api_broadcaster")
     mock_request_twitch_api.side_effect = RequestException("test exception")
     mock_broadcaster = mocker.Mock()
@@ -512,7 +506,6 @@ def test_get_rewards_403(app, mocker):  # pylint: disable=unused-argument
 
 def test_get_firsts(app, mocker, init_db):
     """Test get_firsts function."""
-
     database = init_db(app)
 
     broadcaster = mocker.Mock()
@@ -542,7 +535,6 @@ def test_get_firsts(app, mocker, init_db):
 
 def test_get_firsts_date_ranges(app, mocker, init_db, patch_current_time):
     """Test get_firsts function."""
-
     database = init_db(app)
 
     broadcaster = mocker.Mock()
@@ -595,9 +587,7 @@ def test_get_firsts_date_ranges(app, mocker, init_db, patch_current_time):
 
 def test_get_firsts_not_found(app, mocker, init_db):
     """Test get_firsts returns an empty dictionary if no firsts exist."""
-
     init_db(app)
-
     broadcaster = mocker.Mock()
     broadcaster.id = defaults.BROADCASTER_ID
 
@@ -609,7 +599,6 @@ def test_get_firsts_not_found(app, mocker, init_db):
 
 def test_create_eventsub(app, mocker):
     """Test create_eventsub function."""
-
     mock_response = mocker.Mock()
     mock_response.json.return_value = defaults.EVENTSUB_JSON
     mock_request_twitch_api = mocker.patch("verifiedfirst.twitch.request_twitch_api_app")
@@ -643,7 +632,6 @@ def test_create_eventsub(app, mocker):
 
 def test_create_eventsub_403(app, mocker):  # pylint: disable=unused-argument
     """Test create_eventsub throws the correct exception if the twitch API returns an error."""
-
     mock_request_twitch_api = mocker.patch("verifiedfirst.twitch.request_twitch_api_app")
     mock_request_twitch_api.side_effect = RequestException("test exception")
     mock_broadcaster = mocker.Mock()
@@ -656,7 +644,6 @@ def test_create_eventsub_403(app, mocker):  # pylint: disable=unused-argument
 
 def test_get_eventsubs(app, mocker):
     """Test get_eventsubs function."""
-
     mock_response = mocker.Mock()
     mock_response.json.return_value = defaults.EVENTSUB_JSON
     mock_request_twitch_api = mocker.patch("verifiedfirst.twitch.request_twitch_api_app")
@@ -677,7 +664,6 @@ def test_get_eventsubs(app, mocker):
 
 def test_get_eventsubs_bad_format(app, mocker):  # pylint: disable=unused-argument
     """Test get_eventsubs throws correct exception when data is in wrong format."""
-
     mock_response = mocker.Mock()
     mock_request_twitch_api = mocker.patch("verifiedfirst.twitch.request_twitch_api_app")
     mock_request_twitch_api.return_value = mock_response
@@ -702,7 +688,6 @@ def test_get_eventsubs_bad_format(app, mocker):  # pylint: disable=unused-argume
 
 def test_get_eventsub_fail(app, mocker):  # pylint: disable=unused-argument
     """Test get_eventsub throws the correct exception if the twitch API returns an error."""
-
     mock_request_twitch_api = mocker.patch("verifiedfirst.twitch.request_twitch_api_app")
     mock_request_twitch_api.side_effect = RequestException("test exception")
     mock_broadcaster = mocker.Mock()
@@ -715,7 +700,6 @@ def test_get_eventsub_fail(app, mocker):  # pylint: disable=unused-argument
 
 def test_delete_eventsub(app, mocker):  # pylint: disable=unused-argument
     """Test delete_eventsub function."""
-
     mock_response = mocker.Mock()
     mock_response.text = "test"
     mock_request_twitch_api = mocker.patch("verifiedfirst.twitch.request_twitch_api_app")
@@ -726,7 +710,6 @@ def test_delete_eventsub(app, mocker):  # pylint: disable=unused-argument
 
 def test_update_eventsub(app, init_db, mocker):
     """Test new eventsub gets created if it doesn't exist."""
-
     database = init_db(app)
 
     mock_get_eventsubs = mocker.patch("verifiedfirst.twitch.get_eventsubs")
@@ -848,7 +831,6 @@ def test_get_users_by_login_api_error(app, mocker):  # pylint: disable=unused-ar
 def test_upsert_user_insert(app, init_db):
     """Test upsert_user creates a new User record when none exists."""
     init_db(app)
-
     from verifiedfirst.models.users import User  # pylint: disable=import-outside-toplevel
 
     user = twitch.upsert_user(defaults.TEST_USER_ID, defaults.TEST_USER_NAME)
@@ -863,7 +845,6 @@ def test_upsert_user_insert(app, init_db):
 def test_upsert_user_update(app, init_db):
     """Test upsert_user updates the name of an existing User record."""
     database = init_db(app)
-
     from verifiedfirst.models.users import User  # pylint: disable=import-outside-toplevel
 
     database.session.add(User(id=defaults.TEST_USER_ID, name="oldname"))
@@ -945,7 +926,6 @@ def test_get_firsts_mixed_legacy_and_new(app, init_db):
 
 def test_update_reward(app, init_db):
     """Test update_reward function."""
-
     database = init_db(app)
 
     broadcaster = Broadcaster(
@@ -967,7 +947,6 @@ def test_update_reward(app, init_db):
 
 def test_get_broadcaster(app, init_db):
     """Test get_broadcaster function."""
-
     database = init_db(app)
 
     expected_broadcaster = Broadcaster(
@@ -986,7 +965,6 @@ def test_get_broadcaster(app, init_db):
 
 def test_get_broadcaster_not_found(app, init_db):
     """Test get_broadcaster returns None if no matching broadcaster is found."""
-
     init_db(app)
 
     broadcaster = twitch.get_broadcaster(defaults.BROADCASTER_ID)

--- a/ebs/tests/test_verify.py
+++ b/ebs/tests/test_verify.py
@@ -1,4 +1,5 @@
 """test_verify.py."""
+
 import base64
 import time
 
@@ -12,7 +13,6 @@ from . import defaults
 
 def test_get_hmac(app, mocker):  # pylint: disable=unused-argument
     """Test the get_hmac function generates a correct hmac."""
-
     message = (defaults.MESSAGE_ID + defaults.MESSAGE_TIMESTAMP + defaults.MESSAGE_DATA).encode(
         "utf-8"
     )
@@ -22,7 +22,6 @@ def test_get_hmac(app, mocker):  # pylint: disable=unused-argument
 
 def test_verify_eventsub_message(app, mocker):  # pylint: disable=unused-argument
     """Test the verify_eventsub_message function."""
-
     mock_request = mocker.Mock()
     mock_get_hmac = mocker.patch("verifiedfirst.verify.get_hmac")
 
@@ -55,7 +54,6 @@ def test_verify_eventsub_message(app, mocker):  # pylint: disable=unused-argumen
 
 def test_verify_jwt(app, mocker, generate_jwt):  # pylint: disable=unused-argument
     """Test the verify_jwt function."""
-
     mock_request = mocker.Mock()
 
     # test the valid jwt decodes correctly
@@ -115,7 +113,6 @@ def function(channel_id, role):
 
 def test_token_required(app, mocker):  # pylint: disable=unused-argument
     """Test the token_required decorator."""
-
     mock_verify_jwt = mocker.patch("verifiedfirst.verify.verify_jwt")
     mock_verify_jwt.return_value = (defaults.CHANNEL_ID, defaults.ROLE)
 

--- a/ebs/verifiedfirst/__init__.py
+++ b/ebs/verifiedfirst/__init__.py
@@ -1,4 +1,5 @@
 """Initialize the app."""
+
 import logging
 import sys
 from typing import TypeVar
@@ -67,7 +68,6 @@ def validate_config(config_class: type[C]) -> None:
     :param config_class: imported config class to validate
     :raises ValueError: if config is invalid
     """
-
     if not config_class.CLIENT_ID:
         raise ValueError(f"Missing env var {config_class.PREFIX}CLIENT_ID")
 

--- a/ebs/verifiedfirst/__main__.py
+++ b/ebs/verifiedfirst/__main__.py
@@ -1,4 +1,5 @@
 """Main entrypoint."""
+
 from verifiedfirst import create_app
 
 

--- a/ebs/verifiedfirst/auth/routes.py
+++ b/ebs/verifiedfirst/auth/routes.py
@@ -1,4 +1,5 @@
 """Auth routes."""
+
 from flask import (
     Blueprint,
     Response,
@@ -18,8 +19,9 @@ bp = Blueprint("auth", __name__)
 
 @bp.route("/auth", methods=["GET"])
 def auth() -> Response:
-    """Endpoint to redirect twitch oauth requests to. Ensures that api auth tokens are stored in the
-    database under the appropriate broadcaster.
+    """Endpoint to redirect twitch oauth requests to.
+
+    Ensures that api auth tokens are stored in the database under the appropriate broadcaster.
 
     :return: javascript that sends a message to the parent window (AUTH_SUCCESSFUL or AUTH_FAILED)
     """
@@ -44,7 +46,6 @@ def auth() -> Response:
 @verify.token_required
 def auth_check(channel_id: int, role: str) -> Response:
     """Checks if the broadcaster auth is valid."""
-
     # pylint: disable=duplicate-code
     if role != "broadcaster":
         abort(403, "user role is not broadcaster")

--- a/ebs/verifiedfirst/config.py
+++ b/ebs/verifiedfirst/config.py
@@ -1,4 +1,5 @@
 """Configuration for the app."""
+
 import os
 from typing import cast
 

--- a/ebs/verifiedfirst/database.py
+++ b/ebs/verifiedfirst/database.py
@@ -1,4 +1,5 @@
 """Initialize the db object."""
+
 from flask_sqlalchemy import SQLAlchemy
 
 db = SQLAlchemy()

--- a/ebs/verifiedfirst/errors/handlers.py
+++ b/ebs/verifiedfirst/errors/handlers.py
@@ -1,4 +1,5 @@
 """Error handlers."""
+
 from typing import cast
 
 from flask import Blueprint, Response, jsonify

--- a/ebs/verifiedfirst/main/routes.py
+++ b/ebs/verifiedfirst/main/routes.py
@@ -1,4 +1,5 @@
 """Main routes."""
+
 from datetime import datetime
 
 from flask import Blueprint, Response, abort, jsonify, make_response, request, current_app
@@ -83,7 +84,6 @@ def rewards(channel_id: int, role: str) -> Response:
     :param role: role of the user making the request
     :return: list of rewards in json format
     """
-
     if role != "broadcaster":
         abort(403, "user role is not broadcaster")
 

--- a/ebs/verifiedfirst/models/broadcasters.py
+++ b/ebs/verifiedfirst/models/broadcasters.py
@@ -1,4 +1,5 @@
 """broadcasters.py."""
+
 from dataclasses import dataclass
 
 from verifiedfirst.database import db

--- a/ebs/verifiedfirst/twitch.py
+++ b/ebs/verifiedfirst/twitch.py
@@ -1,4 +1,5 @@
 """Functions related to the twitch api."""
+
 from collections import defaultdict
 from typing import Any, List, Tuple
 from datetime import datetime
@@ -137,15 +138,16 @@ def request_twitch_api(access_token: str, request: Request) -> Response:
 
 
 def request_twitch_api_broadcaster(broadcaster: Broadcaster, request: Request) -> Response:
-    """Request the twitch api with a user (broadcaster) token. If the request fails due to the auth
-    token being expired, the token is attempted to be refreshed and the request is retried.
+    """Request the twitch api with a user (broadcaster) token.
+
+    If the request fails due to the auth token being expired, the token is attempted to be refreshed
+    and the request is retried.
 
     :param broadcaster: broadcaster to perform the request for
     :param request: request to send to the twitch api
     :raises RequestException: if the request fails
     :return: response from the request
     """
-
     try:
         resp = request_twitch_api(broadcaster.access_token, request)
         resp.raise_for_status()
@@ -296,7 +298,6 @@ def get_firsts(
     :param end_time: count firsts at or before this date
     :return: dictionary of first counts by user e.g {"user1": 5, "user2": 3}
     """
-
     if start_time is None:
         start_time = datetime.min
     if end_time is None:
@@ -568,7 +569,6 @@ def get_broadcaster(broadcaster_id: int) -> Broadcaster | None:
     :param broadcaster_id: id of the broadcaster to retrieve
     :return: matching broadcaster object or None
     """
-
     try:
         broadcaster = Broadcaster.query.filter(Broadcaster.id == broadcaster_id).one()
     except NoResultFound:

--- a/ebs/verifiedfirst/verify.py
+++ b/ebs/verifiedfirst/verify.py
@@ -1,4 +1,5 @@
 """Functions related to verification of auth tokens."""
+
 from functools import wraps
 from typing import Callable, TypeVar, Tuple, cast
 import base64


### PR DESCRIPTION
## Summary

- `docformatter` was failing on every PR that touches `ebs/` because the CI workflow only triggers on `ebs/**` changes — so these violations were never caught on dependency-bump commits
- No logic changes — only blank-line adjustments around docstrings to satisfy `docformatter --check`
- Merge this first so the bug-fix PRs (#147, #148, #149, #150) pass CI cleanly

## Test plan

- [ ] `tox -c ebs/tox.ini` passes locally after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)