### PR TITLE
Upgrade docformatter to run on Python 3.14

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - "3.13"
         - "3.14"
 
     steps:

--- a/ebs/tox.ini
+++ b/ebs/tox.ini
@@ -4,8 +4,7 @@ envlist = py314,pylint,black,docformatter,mypy
 
 [gh-actions]
 python =
-    3.14: py314,pylint,black,mypy
-    3.13: docformatter
+    3.14: py314,pylint,black,docformatter,mypy
 
 [coverage:html]
 show_contexts = True
@@ -39,7 +38,7 @@ commands =
     black --check --diff --color verifiedfirst tests
 
 [testenv:docformatter]
-base_python = python3.13 # docformatter doesn't support 3.14 yet
+base_python = python3.14
 skip_install = True
 deps =
     docformatter


### PR DESCRIPTION
## Summary

- docformatter 1.7.8 (released April 2026) added Python 3.14 support by removing the broken `untokenize` dependency
- Removes the Python 3.13 workaround in `tox.ini` and consolidates `docformatter` into the Python 3.14 tox envlist
- Drops `"3.13"` from the CI matrix in `run-tests.yml` since it was only there to run docformatter

## Test plan

- [x] Confirm the `docformatter` tox env passes on Python 3.14 in CI
- [x] Confirm no other tox envs are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)