### PR TITLE
Add Dependabot auto-merge workflows

### DIFF
--- a/.github/workflows/dependabot-auto-merge-actions.yml
+++ b/.github/workflows/dependabot-auto-merge-actions.yml
@@ -1,0 +1,21 @@
+name: Auto-merge Dependabot github-actions PRs
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths: [".github/**"]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Merge PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --rebase "$PR_URL"

--- a/.github/workflows/dependabot-auto-merge-npm.yml
+++ b/.github/workflows/dependabot-auto-merge-npm.yml
@@ -1,0 +1,42 @@
+name: Auto-merge Dependabot npm PRs
+
+on:
+  workflow_run:
+    workflows: ["Run frontend tests", "Run ESLint on javascript"]
+    types: [completed]
+    branches: ["dependabot/npm_and_yarn/**"]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Get PR info
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/pull_requests" --jq '.[0]')
+          echo "url=$(echo $pr | jq -r '.html_url')" >> $GITHUB_OUTPUT
+          echo "sha=$(echo $pr | jq -r '.head.sha')" >> $GITHUB_OUTPUT
+
+      - name: Check both test and lint have passed
+        id: checks
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          passed=$(gh api "repos/${{ github.repository }}/commits/${{ steps.pr.outputs.sha }}/check-runs" \
+            --jq '[.check_runs[] | select(.name == "test" or .name == "lint")] | (length == 2) and (map(.conclusion == "success") | all)')
+          echo "passed=$passed" >> $GITHUB_OUTPUT
+
+      - name: Merge PR
+        if: steps.checks.outputs.passed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --rebase "${{ steps.pr.outputs.url }}"

--- a/.github/workflows/dependabot-auto-merge-python.yml
+++ b/.github/workflows/dependabot-auto-merge-python.yml
@@ -1,0 +1,33 @@
+name: Auto-merge Dependabot pip and docker PRs
+
+on:
+  workflow_run:
+    workflows: ["Run tox tests"]
+    types: [completed]
+    branches:
+      - "dependabot/pip/**"
+      - "dependabot/docker/**"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Get PR URL
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          url=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/pull_requests" --jq '.[0].html_url')
+          echo "url=$url" >> $GITHUB_OUTPUT
+
+      - name: Merge PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --rebase "${{ steps.pr.outputs.url }}"


### PR DESCRIPTION
## Summary

- Adds three auto-merge workflows for each Dependabot ecosystem type (npm, pip/docker, github-actions)
- npm PRs wait for both `test` and `lint` checks to pass via `workflow_run` trigger
- pip and docker PRs wait for `build (3.14)` (tox) to pass via `workflow_run` trigger
- github-actions PRs merge immediately on open (no tests run for workflow file bumps)
- All merges use `--rebase` to maintain linear history, consistent with the repo's rebase-only merge setting

## Repo settings changed (via API, not in this PR)

- Rebase-only merges enforced (merge commits and squash disabled)
- Required linear history enabled on `main`
- Force pushes blocked on `main` via ruleset (applies to all users including admins)

## Test plan

- [x] Open a test Dependabot npm PR and confirm it auto-merges after frontend tests and ESLint pass
- [x] Open a test Dependabot pip PR and confirm it auto-merges after tox passes
- [x] Confirm force push to `main` is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)