### PR TITLE
Fix Dependabot auto-merge PR lookup 404

### DIFF
--- a/.github/workflows/dependabot-auto-merge-npm.yml
+++ b/.github/workflows/dependabot-auto-merge-npm.yml
@@ -22,9 +22,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pr=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/pull_requests" --jq '.[0]')
-          echo "url=$(echo $pr | jq -r '.html_url')" >> $GITHUB_OUTPUT
-          echo "sha=$(echo $pr | jq -r '.head.sha')" >> $GITHUB_OUTPUT
+          url=$(gh api "repos/${{ github.repository }}/pulls" \
+            -f state=open \
+            -f head="${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}" \
+            --jq '.[0].html_url')
+          echo "url=$url" >> $GITHUB_OUTPUT
+          echo "sha=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_OUTPUT
 
       - name: Check both test and lint have passed
         id: checks

--- a/.github/workflows/dependabot-auto-merge-python.yml
+++ b/.github/workflows/dependabot-auto-merge-python.yml
@@ -24,7 +24,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          url=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/pull_requests" --jq '.[0].html_url')
+          url=$(gh api "repos/${{ github.repository }}/pulls" \
+            -f state=open \
+            -f head="${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}" \
+            --jq '.[0].html_url')
           echo "url=$url" >> $GITHUB_OUTPUT
 
       - name: Merge PR


### PR DESCRIPTION
## Summary

- Fixes a 404 error in the npm and pip/docker auto-merge workflows
- The `/actions/runs/{id}/pull_requests` API endpoint returns 404 for Dependabot PRs
- Replaces it with a lookup against `/pulls` filtered by branch name, using `github.event.workflow_run.head_branch`
- The commit sha is now taken directly from `github.event.workflow_run.head_sha` rather than the PR object

## Test plan

- [ ] Confirm a Dependabot npm PR auto-merges after frontend tests and ESLint pass
- [ ] Confirm a Dependabot pip PR auto-merges after tox passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)