### PR TITLE
Fix Dependabot auto-merge PR lookup using GET method

### DIFF
--- a/.github/workflows/dependabot-auto-merge-npm.yml
+++ b/.github/workflows/dependabot-auto-merge-npm.yml
@@ -23,6 +23,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           url=$(gh api "repos/${{ github.repository }}/pulls" \
+            --method GET \
             -f state=open \
             -f head="${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}" \
             --jq '.[0].html_url')

--- a/.github/workflows/dependabot-auto-merge-python.yml
+++ b/.github/workflows/dependabot-auto-merge-python.yml
@@ -25,6 +25,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           url=$(gh api "repos/${{ github.repository }}/pulls" \
+            --method GET \
             -f state=open \
             -f head="${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}" \
             --jq '.[0].html_url')


### PR DESCRIPTION
## Summary

- Fixes a 403 error in the npm and pip/docker auto-merge workflows
- The `-f` flag in `gh api` defaults to POST when fields are provided, causing GitHub to treat the request as a PR creation attempt
- Adds `--method GET` so the fields are sent as query parameters instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)