### PR TITLE
Retry Dependabot auto-merge on race condition

### DIFF
--- a/.github/workflows/dependabot-auto-merge-actions.yml
+++ b/.github/workflows/dependabot-auto-merge-actions.yml
@@ -18,4 +18,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --rebase "$PR_URL"
+        run: |
+          for i in {1..3}; do
+            gh pr merge --rebase "$PR_URL" && break
+            [ $i -lt 3 ] && sleep $((15 + RANDOM % 15)) || exit 1
+          done

--- a/.github/workflows/dependabot-auto-merge-npm.yml
+++ b/.github/workflows/dependabot-auto-merge-npm.yml
@@ -43,4 +43,8 @@ jobs:
         if: steps.checks.outputs.passed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge --rebase "${{ steps.pr.outputs.url }}"
+        run: |
+          for i in {1..3}; do
+            gh pr merge --rebase "${{ steps.pr.outputs.url }}" && break
+            [ $i -lt 3 ] && sleep $((15 + RANDOM % 15)) || exit 1
+          done

--- a/.github/workflows/dependabot-auto-merge-python.yml
+++ b/.github/workflows/dependabot-auto-merge-python.yml
@@ -34,4 +34,8 @@ jobs:
       - name: Merge PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge --rebase "${{ steps.pr.outputs.url }}"
+        run: |
+          for i in {1..3}; do
+            gh pr merge --rebase "${{ steps.pr.outputs.url }}" && break
+            [ $i -lt 3 ] && sleep $((15 + RANDOM % 15)) || exit 1
+          done


### PR DESCRIPTION
## Summary

- Fixes a race condition where multiple Dependabot PRs merging simultaneously cause "Base branch was modified" errors
- Retries the merge up to 3 times with a random 15–30s sleep between attempts
- Jitter prevents concurrent merge workflows from colliding again on the retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)