### PR TITLE
Add opt-in "Cards" leaderboard style

### DIFF
--- a/src/config/Config.jsx
+++ b/src/config/Config.jsx
@@ -16,6 +16,7 @@ export default function Config() {
   const [configuredTitle, setConfiguredTitle] = useState(defaultTitle);
   const [configuredRewardId, setConfiguredRewardId] = useState(null);
   const [configuredTimeRange, setConfiguredTimeRange] = useState("all_time");
+  const [configuredStyle, setConfiguredStyle] = useState("classic");
   const [rewardsLoading, setRewardsLoading] = useState(false);
   const [rewardsError, setRewardsError] = useState(null);
   const [authStatus, setAuthStatus] = useState(null); // null | "connecting" | "success" | "failed"
@@ -58,6 +59,7 @@ export default function Config() {
           if (config.title) setConfiguredTitle(config.title);
           if (config.rewardId) setConfiguredRewardId(config.rewardId);
           if (config.timeRange) setConfiguredTimeRange(config.timeRange);
+          if (config.leaderboardStyle) setConfiguredStyle(config.leaderboardStyle);
         } catch (e) {
           console.error("invalid config", e);
           configRef.current = {};
@@ -113,6 +115,7 @@ export default function Config() {
     const form = e.target;
     const title = form.elements["panel_title"].value;
     const timeRange = form.elements["time_range"].value;
+    const leaderboardStyle = form.elements["leaderboard_style"].value;
     const rewardId = form.elements["reward_select"].value;
 
     if (!rewardId) {
@@ -126,7 +129,7 @@ export default function Config() {
 
     // Save title and time range to Twitch broadcaster config storage
     const twitch = window.Twitch.ext;
-    const updatedConfig = { ...configRef.current, title, timeRange };
+    const updatedConfig = { ...configRef.current, title, timeRange, leaderboardStyle };
     twitch.configuration.set("broadcaster", "1", JSON.stringify(updatedConfig));
     configRef.current = updatedConfig;
 
@@ -270,6 +273,18 @@ export default function Config() {
                 <option value="month">Month</option>
                 <option value="year">Year</option>
                 <option value="all_time">All Time</option>
+              </select>
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="leaderboard_style">Leaderboard style:</label>
+              <select
+                name="leaderboard_style"
+                id="leaderboard_style"
+                defaultValue={configuredStyle}
+              >
+                <option value="classic">Classic</option>
+                <option value="cards">Cards</option>
               </select>
             </div>
 

--- a/src/config/Config.test.jsx
+++ b/src/config/Config.test.jsx
@@ -190,6 +190,59 @@ describe("Config", () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // Leaderboard style
+  // -------------------------------------------------------------------------
+  it("defaults the leaderboard style dropdown to Classic", async () => {
+    render(<Config />);
+    await authorize({ authed: true });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("combobox", { name: /leaderboard style/i }),
+      ).toHaveValue("classic");
+    });
+  });
+
+  it("pre-populates leaderboard style from existing broadcaster config", async () => {
+    window.Twitch.ext.configuration.broadcaster = {
+      content: JSON.stringify({ leaderboardStyle: "cards" }),
+    };
+    render(<Config />);
+    await act(async () => { onChangedCallback(); });
+    await authorize({ authed: true });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("combobox", { name: /leaderboard style/i }),
+      ).toHaveValue("cards");
+    });
+  });
+
+  it("saves leaderboard style to Twitch configuration on submit", async () => {
+    createEventsub.mockResolvedValue({ eventsub_id: "sub-123" });
+    render(<Config />);
+    await authorize({ authed: true });
+
+    await waitFor(() => screen.getByLabelText(/Leaderboard title/i));
+
+    await act(async () => {
+      fireEvent.change(
+        screen.getByRole("combobox", { name: /leaderboard style/i }),
+        { target: { value: "cards" } },
+      );
+      fireEvent.submit(screen.getByRole("button", { name: "Save" }).closest("form"));
+    });
+
+    await waitFor(() => {
+      expect(window.Twitch.ext.configuration.set).toHaveBeenCalledWith(
+        "broadcaster",
+        "1",
+        expect.stringContaining('"leaderboardStyle":"cards"'),
+      );
+    });
+  });
+
   it("shows error message when createEventsub fails", async () => {
     createEventsub.mockRejectedValue(new Error("eventsub failed"));
     render(<Config />);

--- a/src/panel/Panel.jsx
+++ b/src/panel/Panel.jsx
@@ -231,8 +231,8 @@ export default function Panel() {
               className={`firsts-row${rank === 1 ? " firsts-row--top" : ""}`}
               key={i}
             >
-              <span className="firsts-rank" aria-hidden="true">
-                {rank}
+              <span className="firsts-count" aria-hidden="true">
+                {count}
               </span>
               <span className="firsts-avatars" aria-hidden="true">
                 {shown.map((u) => (
@@ -251,7 +251,7 @@ export default function Panel() {
                 )}
               </span>
               <span className="row-detail">
-                {count}x | {users.join(", ")}
+                <span className="row-detail-text">{users.join(", ")}</span>
               </span>
             </div>
           );

--- a/src/panel/Panel.jsx
+++ b/src/panel/Panel.jsx
@@ -61,12 +61,35 @@ function groupFirsts(firsts) {
     .map(([count, users]) => ({ count: Number(count), users }));
 }
 
+/** First 1-2 characters of a username, uppercased, for the "cards" style avatar badge. */
+function initials(username) {
+  return username.slice(0, 2).toUpperCase();
+}
+
+/** Deterministic djb2-style string hash, used only for avatar color selection. */
+function hashUsername(username) {
+  let hash = 0;
+  for (let i = 0; i < username.length; i++) {
+    hash = username.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return hash;
+}
+
+/** Deterministic per-username avatar background color for the "cards" style. */
+function avatarColor(username) {
+  const hue = Math.abs(hashUsername(username)) % 360;
+  return `hsl(${hue}, 55%, 40%)`;
+}
+
+const MAX_AVATARS = 3;
+
 export default function Panel() {
   // Use refs for values set inside Twitch SDK callbacks to avoid stale closure issues
   const authRef = useRef(null);
   const configuredRangeRef = useRef("all_time");
 
   const [title, setTitle] = useState(defaultTitle);
+  const [leaderboardStyle, setLeaderboardStyle] = useState("classic");
   const [activeRange, setActiveRange] = useState(null);
   const [customStart, setCustomStart] = useState("");
   const [customEnd, setCustomEnd] = useState("");
@@ -121,6 +144,7 @@ export default function Panel() {
           const config = JSON.parse(twitch.configuration.broadcaster.content);
           if (config.title) setTitle(config.title);
           if (config.timeRange) configuredRangeRef.current = config.timeRange;
+          if (config.leaderboardStyle) setLeaderboardStyle(config.leaderboardStyle);
         } catch (e) {
           console.error("invalid config", e);
         }
@@ -161,7 +185,7 @@ export default function Panel() {
     if (customStart && val) loadFirsts("custom", customStart, val);
   };
 
-  const renderLeaderboard = () => {
+  const renderStatus = () => {
     if (loading) return <p>Loading...</p>;
     if (error) {
       return (
@@ -175,6 +199,12 @@ export default function Panel() {
     if (firsts === null || (firsts && Object.keys(firsts).length === 0)) {
       return <p>{"No one has been first yet ¯\\_(ツ)_/¯"}</p>;
     }
+    return null;
+  };
+
+  const renderClassicLeaderboard = () => {
+    const status = renderStatus();
+    if (status) return status;
     if (firsts === undefined) return null;
 
     return groupFirsts(firsts).map(({ count, users }, i) => (
@@ -182,6 +212,52 @@ export default function Panel() {
         {count}x | {users.join(", ")}
       </p>
     ));
+  };
+
+  const renderCardsLeaderboard = () => {
+    const status = renderStatus();
+    if (status) return status;
+    if (firsts === undefined) return null;
+
+    return (
+      <div className="firsts-list">
+        {groupFirsts(firsts).map(({ count, users }, i) => {
+          const rank = i + 1;
+          const shown = users.slice(0, MAX_AVATARS);
+          const overflow = users.length - shown.length;
+
+          return (
+            <div
+              className={`firsts-row${rank === 1 ? " firsts-row--top" : ""}`}
+              key={i}
+            >
+              <span className="firsts-rank" aria-hidden="true">
+                {rank}
+              </span>
+              <span className="firsts-avatars" aria-hidden="true">
+                {shown.map((u) => (
+                  <span
+                    className="firsts-avatar"
+                    key={u}
+                    style={{ backgroundColor: avatarColor(u) }}
+                  >
+                    {initials(u)}
+                  </span>
+                ))}
+                {overflow > 0 && (
+                  <span className="firsts-avatar firsts-avatar--overflow">
+                    +{overflow}
+                  </span>
+                )}
+              </span>
+              <span className="row-detail">
+                {count}x | {users.join(", ")}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    );
   };
 
   return (
@@ -213,9 +289,13 @@ export default function Panel() {
         </div>
       )}
       <div className="firsts">
-        <blockquote>
-          <div id="firsts">{renderLeaderboard()}</div>
-        </blockquote>
+        {leaderboardStyle === "cards" ? (
+          <div id="firsts">{renderCardsLeaderboard()}</div>
+        ) : (
+          <blockquote>
+            <div id="firsts">{renderClassicLeaderboard()}</div>
+          </blockquote>
+        )}
       </div>
       <div className="footer">
         <p id="lastupdated">

--- a/src/panel/Panel.test.jsx
+++ b/src/panel/Panel.test.jsx
@@ -132,6 +132,70 @@ describe("Panel", () => {
   });
 
   // -------------------------------------------------------------------------
+  // Cards leaderboard style
+  // -------------------------------------------------------------------------
+  it("renders card rows instead of a classic list when cards style is configured", async () => {
+    fetchFirsts.mockResolvedValue({ saundo__: 69, chetnitro: 37 });
+    render(<Panel />);
+    await applyConfig({ leaderboardStyle: "cards" });
+    await authorize();
+
+    await waitFor(() => {
+      expect(document.querySelector("blockquote")).not.toBeInTheDocument();
+      expect(document.querySelectorAll(".firsts-row")).toHaveLength(2);
+    });
+  });
+
+  it("shows the firsts count (not rank) in the count badge", async () => {
+    fetchFirsts.mockResolvedValue({ saundo__: 69, chetnitro: 37 });
+    render(<Panel />);
+    await applyConfig({ leaderboardStyle: "cards" });
+    await authorize();
+
+    await waitFor(() => {
+      const counts = Array.from(
+        document.querySelectorAll(".firsts-count"),
+      ).map((el) => el.textContent.trim());
+      expect(counts).toEqual(["69", "37"]);
+    });
+  });
+
+  it("renders one avatar per tied user, plus an overflow badge past the max shown", async () => {
+    fetchFirsts.mockResolvedValue({
+      user1: 1,
+      user2: 1,
+      user3: 1,
+      user4: 1,
+      user5: 1,
+    });
+    render(<Panel />);
+    await applyConfig({ leaderboardStyle: "cards" });
+    await authorize();
+
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll(".firsts-avatar:not(.firsts-avatar--overflow)"),
+      ).toHaveLength(3);
+      expect(screen.getByText("+2")).toBeInTheDocument();
+      expect(
+        screen.getByText("user1, user2, user3, user4, user5"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("does not show the classic 'Nx' count prefix in card row text", async () => {
+    fetchFirsts.mockResolvedValue({ saundo__: 69 });
+    render(<Panel />);
+    await applyConfig({ leaderboardStyle: "cards" });
+    await authorize();
+
+    await waitFor(() => {
+      expect(screen.getByText("saundo__")).toBeInTheDocument();
+      expect(screen.queryByText(/69x/)).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Time-range selection
   // -------------------------------------------------------------------------
   it("uses the configured default time range on first load", async () => {

--- a/src/theme.css
+++ b/src/theme.css
@@ -96,6 +96,108 @@ blockquote p {
 }
 
 /* ---------------------------------------------------------------
+   Leaderboard area — "cards" style (opt-in via config)
+--------------------------------------------------------------- */
+.firsts-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.firsts-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  background: rgb(245, 244, 250);
+  transition: background-color 0.15s ease;
+}
+
+.firsts-row:hover {
+  background: rgb(236, 233, 247);
+}
+
+.firsts-row--top {
+  background: rgba(169, 112, 255, 0.14);
+  box-shadow: inset 2.4px 0 0 rgb(169, 112, 255);
+}
+
+.firsts-row--top:hover {
+  background: rgba(169, 112, 255, 0.2);
+}
+
+#root[data-theme="dark"] .firsts-row {
+  background: rgb(32, 32, 36);
+}
+
+#root[data-theme="dark"] .firsts-row:hover {
+  background: rgb(42, 42, 48);
+}
+
+#root[data-theme="dark"] .firsts-row--top {
+  background: rgba(169, 112, 255, 0.18);
+}
+
+#root[data-theme="dark"] .firsts-row--top:hover {
+  background: rgba(169, 112, 255, 0.24);
+}
+
+.firsts-rank {
+  flex-shrink: 0;
+  width: 16px;
+  text-align: center;
+  font-size: 12px;
+  font-weight: 600;
+  opacity: 0.55;
+}
+
+.firsts-row--top .firsts-rank {
+  color: rgb(169, 112, 255);
+  opacity: 1;
+}
+
+.firsts-avatars {
+  display: flex;
+  flex-shrink: 0;
+}
+
+.firsts-avatar {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 9px;
+  font-weight: 700;
+  color: #fff;
+  flex-shrink: 0;
+}
+
+.firsts-avatar + .firsts-avatar {
+  margin-left: -6px;
+  border: 1.5px solid rgb(245, 244, 250);
+}
+
+#root[data-theme="dark"] .firsts-avatar + .firsts-avatar {
+  border-color: rgb(32, 32, 36);
+}
+
+.firsts-avatar--overflow {
+  background: rgb(120, 120, 128);
+}
+
+.row-detail {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+}
+
+/* ---------------------------------------------------------------
    Footer (last-updated timestamp)
 --------------------------------------------------------------- */
 .footer {

--- a/src/theme.css
+++ b/src/theme.css
@@ -83,6 +83,25 @@ p {
   overflow-y: scroll;
   overflow-x: hidden;
   margin-top: 12px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(128, 128, 128, 0.4) transparent;
+}
+
+.firsts::-webkit-scrollbar {
+  width: 6px;
+}
+
+.firsts::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.firsts::-webkit-scrollbar-thumb {
+  background-color: rgba(128, 128, 128, 0.4);
+  border-radius: 3px;
+}
+
+.firsts::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(128, 128, 128, 0.6);
 }
 
 blockquote {
@@ -105,6 +124,8 @@ blockquote p {
 }
 
 .firsts-row {
+  position: relative;
+  z-index: 0;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -112,6 +133,10 @@ blockquote p {
   border-radius: 8px;
   background: rgb(245, 244, 250);
   transition: background-color 0.15s ease;
+}
+
+.firsts-row:hover {
+  z-index: 5;
 }
 
 .firsts-row:hover {
@@ -143,16 +168,16 @@ blockquote p {
   background: rgba(169, 112, 255, 0.24);
 }
 
-.firsts-rank {
+.firsts-count {
   flex-shrink: 0;
-  width: 16px;
+  min-width: 16px;
   text-align: center;
   font-size: 12px;
   font-weight: 600;
   opacity: 0.55;
 }
 
-.firsts-row--top .firsts-rank {
+.firsts-row--top .firsts-count {
   color: rgb(169, 112, 255);
   opacity: 1;
 }
@@ -191,10 +216,40 @@ blockquote p {
 .row-detail {
   flex: 1;
   min-width: 0;
+  position: relative;
+  height: 19.5px;
+  overflow: hidden;
+}
+
+.row-detail-text {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  overflow-wrap: break-word;
   font-size: 13px;
+  border-radius: 6px;
+}
+
+.firsts-row:hover .row-detail {
+  overflow: visible;
+}
+
+.firsts-row:hover .row-detail-text {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
+  padding: 2px 4px;
+  background: rgb(236, 233, 247);
+  box-shadow: 0 2px 8px rgba(20, 10, 40, 0.18);
+}
+
+#root[data-theme="dark"] .firsts-row:hover .row-detail-text {
+  background: rgb(42, 42, 48);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
 }
 
 /* ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds a new broadcaster-configurable leaderboard style ("Cards") alongside the existing plain-list style, which stays the default so no existing panel changes appearance unless the broadcaster opts in.
- Cards style: rounded row per rank, colored avatar-initial badge per chatter (deterministic hash-based color, since only usernames/counts are available), and a purple highlight on the #1 row using the extension's existing accent color.
- New "Leaderboard style" dropdown on the Config page (Classic/Cards), saved alongside the existing title/time-range config.

Frontend only — no EBS/backend changes in this PR.

## Test plan
- [x] `npm test` — all 38 existing tests pass unmodified (classic path is untouched byte-for-byte)
- [x] Verified both styles render correctly in light and dark theme via a local preview harness
- [ ] Manual check in the Twitch Developer Rig / hosted test panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)